### PR TITLE
Save loaded blocks

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -4,6 +4,8 @@ namespace IrishDistillers\SirTrevorTwig;
 
 class Extension extends \Twig_Extension
 {
+    private $loadedBlocks = [];
+
     public function getFunctions() : array
     {
         return [
@@ -24,6 +26,9 @@ class Extension extends \Twig_Extension
             array_map(
                 function($block) use ($environment) {
                     try {
+                        $block->data->rand = mt_rand();
+                        $this->loadedBlocks[] = $block;
+
                         return $environment->render(
                             'SirTrevorTwig:_snippets:sirtrevor/'.$block->type.'.html.twig',
                             ['data' => $block->data]
@@ -35,5 +40,10 @@ class Extension extends \Twig_Extension
                 $content->data
             )
         );
+    }
+
+    public function getLoadedBlocks() : array
+    {
+        return $this->loadedBlocks;
     }
 }


### PR DESCRIPTION
So that we can query what Sir Trevor blocks have been loaded, this
is for blocks that require JS callbacks. Using the `rand` ID that gets
attached you can generate global loading functions.