### PR TITLE
Extracts rendering functionality out of Extension and into standalone class

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -2,13 +2,19 @@
 
 namespace IrishDistillers\SirTrevorTwig;
 
+use IrishDistillers\SirTrevorTwig\SirTrevor;
+
 class Extension extends \Twig_Extension
 {
-    private $loadedBlocks = [];
+    /**
+     * @var IrishDistillers\SirTrevorTwig\SirTrevor
+     */
+    protected $sirTrevor;
 
-    private $defaultOptions = [
-        'mobile' => false
-    ];
+    public function __construct(SirTrevor $sirTrevor)
+    {
+        $this->sirTrevor = $sirTrevor;
+    }
 
     public function getFunctions() : array
     {
@@ -26,35 +32,11 @@ class Extension extends \Twig_Extension
 
     public function sirtrevor(\Twig_Environment $environment, \stdClass $content, array $options = []) : string
     {
-        return implode(
-            "\n",
-            array_map(
-                function ($block) use ($environment, $options) {
-                    try {
-                        // Deep copy hack, otherwise the rand value gets overwritten
-                        $block = unserialize(serialize($block));
-
-                        $block->data->rand = mt_rand();
-                        $this->loadedBlocks[] = $block;
-
-                        return $environment->render(
-                            'SirTrevorTwig:_snippets:sirtrevor/'.$block->type.'.html.twig',
-                            [
-                                'data' => $block->data,
-                                'options' => array_merge($this->defaultOptions, $options)
-                            ]
-                        );
-                    } catch (\Twig_Error_Loader $exception) {
-                        return sprintf('<!-- Snippet type: "%s" not found -->', $block->type);
-                    }
-                },
-                $content->data
-            )
-        );
+        return $this->sirTrevor->render($content, $options, $environment);
     }
 
     public function getLoadedBlocks() : array
     {
-        return $this->loadedBlocks;
+        return $this->sirTrevor->getLoadedBlocks();
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,19 +6,12 @@ Add the following to your `composer.json`:
 
 ```json
 "repositories": [{
-    "type": "vcs",
-    "url": "git@github.com:irishdistillers/sir-trevor-twig-bundle.git"
+    "type": "composer",
+    "url": "https://satis.idlcloud.com/"
 }]
 ```
 
-and
-
-```json
-"require": {
-    "irishdistillers/sir-trevor-twig-bundle": "dev-master"
-```
-
-Then run `composer update irishdistillers/sir-trevor-twig-bundle`.
+Then run `composer require irishdistillers/sir-trevor-twig-bundle`.
 
 Finally, add the following to your `app/AppKernel.php` bundles section:
 
@@ -47,6 +40,16 @@ return $this->render(
 <div>
     {{ sirtrevor(content) | raw }}
 </div>
+```
+
+You can also use the standalone `sir_trevor.renderer` to render content outside of a template:;
+
+```php
+public function renderBlockAction(\IrishDistillers\SirTrevorTwig\SirTrevor $sirTrevor)
+{
+    $sirTrevorContent = $this->someApi->fetchContent();
+    return $this->sirTrevor->render($sirTrevorContent);
+}
 ```
 
 ## Overiding snippets

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,5 +2,20 @@ services:
     sir_trevor_twig_extension:
         class: IrishDistillers\SirTrevorTwig\Extension
         public: false
+        arguments:
+            - "@sir_trevor.internal_renderer"
         tags:
             - { name: twig.extension }
+
+    # We need two Renderer classes, one for the Extension to use and a public facing one
+    # The internal class cannot receive a `templating` argument because it creates a
+    # circular dependency. Instead it receives the templating engine as a method argument.
+
+    sir_trevor.internal_renderer:
+        public: false
+        class: IrishDistillers\SirTrevorTwig\SirTrevor
+
+    sir_trevor.renderer:
+        class: IrishDistillers\SirTrevorTwig\SirTrevor
+        arguments:
+            - "@templating"

--- a/SirTrevor.php
+++ b/SirTrevor.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace IrishDistillers\SirTrevorTwig;
+
+use Symfony\Bundle\TwigBundle\TwigEngine;
+
+class SirTrevor
+{
+    /**
+     * @var Symfony\Bundle\TwigBundle\TwigEngine
+     */
+    protected $templating = null;
+
+    /**
+     * @var array
+     */
+    protected $loadedBlocks = [];
+
+    /**
+     * @var array
+     */
+    protected $defaultOptions = [
+        'mobile' => false
+    ];
+
+    public function __construct(TwigEngine $templating = null)
+    {
+        $this->templating = $templating;
+    }
+
+    public function render(\stdClass $content, array $options = [], \Twig_Environment $environment = null) : string
+    {
+        if (is_null($environment)) {
+            $environment = $this->templating;
+        }
+
+        return implode(
+            "\n",
+            array_map(
+                function ($block) use ($environment, $options) {
+                    try {
+                        // Deep copy hack, otherwise the rand value gets overwritten
+                        $block = unserialize(serialize($block));
+
+                        $block->data->rand = mt_rand();
+                        $this->loadedBlocks[] = $block;
+
+                        return $environment->render(
+                            'SirTrevorTwig:_snippets:sirtrevor/'.$block->type.'.html.twig',
+                            [
+                                'data' => $block->data,
+                                'options' => array_merge($this->defaultOptions, $options)
+                            ]
+                        );
+                    } catch (\Twig_Error_Loader $exception) {
+                        return sprintf('<!-- Snippet type: "%s" not found -->', $block->type);
+                    }
+                },
+                $content->data
+            )
+        );
+    }
+
+    public function getLoadedBlocks() : array
+    {
+        return $this->loadedBlocks;
+    }
+}


### PR DESCRIPTION
Making the Extension public and injecting it is awkward, instead create a standalone class that is responsible for the rendering logic.