### PR TITLE
Updated code to get rid of deprecation message

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,5 +1,5 @@
 services:
-    sir_trevor_twig_extension:
+    IrishDistillers\SirTrevorTwig\Extension:
         class: IrishDistillers\SirTrevorTwig\Extension
         public: false
         arguments:


### PR DESCRIPTION
Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "sir_trevor_twig_extension" service to "IrishDistillers\SirTrevorTwig\Extension" instead.